### PR TITLE
Make work with Korma 0.4.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/geppetto "3.1.0"
+(defproject cc.artifice/geppetto "3.2.0"
   :description "Backend support for experimental work."
   :url "http://geppetto.artifice.cc"
   :license {:name "MIT License"
@@ -9,8 +9,9 @@
                  [org.clojure/core.cache "0.6.5"]
                  [myguidingstar/clansi "1.3.0"]
                  [cc.artifice/propertea "1.4.1"]
-                 [korma "0.4.2"]
+                 [korma "0.4.5"]
                  [mysql/mysql-connector-java "6.0.3"]
+                 [com.h2database/h2 "1.4.187"]
                  [org.apache.commons/commons-math3 "3.6.1"]
                  [clj-time "0.12.0"]
                  [clojure-csv/clojure-csv "2.0.2"]

--- a/src/geppetto/misc.clj
+++ b/src/geppetto/misc.clj
@@ -1,6 +1,6 @@
 (ns geppetto.misc
   (:use [korma.db :only [mysql]])
-  (:use [korma.config])
+  ;;(:use [korma.config])
   (:import (java.util Date))
   (:import (java.text SimpleDateFormat))
   (:use [taoensso.timbre]))
@@ -10,9 +10,9 @@
 (defn setup-geppetto
   [dbhost dbport dbname dbuser dbpassword quiet?]
   (if quiet? (set-level! :warn) (set-level! :info))
-  (set-delimiters "`")
   (dosync (alter geppetto-db (constantly (mysql {:db dbname :port dbport :user dbuser
-                                                 :password dbpassword :host dbhost})))))
+                                                 :password dbpassword :host dbhost
+                                                 :delimeters "`"})))))
 
 (defn format-date-ms
   [ms]

--- a/test/geppetto/test_fixtures.clj
+++ b/test/geppetto/test_fixtures.clj
@@ -6,7 +6,7 @@
   (:use [geppetto.parameters])
   (:use [geppetto.models])
   (:use [geppetto.random])
-  (:use [korma db core config])
+  (:use [korma db core])
   (:require [taoensso.timbre :as timbre]))
 
 (defn establish-params
@@ -18,11 +18,9 @@
 
 (defn in-memory-db
   [f]
-  (dosync (alter geppetto-db (constantly {:classname "org.h2.Driver"
-                                          :subprotocol "h2"
-                                          :subname "mem:test;DB_CLOSE_DELAY=-1"})))
-  (set-delimiters "")
-  (set-naming {:keys str/lower-case})
+  (dosync (alter geppetto-db (constantly (h2 {:db "mem:test"
+                                              :naming {:keys str/lower-case :fields str/lower-case}
+                                              :delimiters "`"}))))
   (with-db @geppetto-db
     (exec-raw (slurp "tables.sql")))
   (establish-params)
@@ -31,9 +29,9 @@
 (defn travis-mysql-db
   [f]
   (sh "mysql" "-u" "travis" "geppetto_test" :in (slurp "tables.sql"))
-  (dosync (alter geppetto-db (constantly (mysql {:db "geppetto_test" :user "travis" :password ""}))))
-  (set-delimiters "")
-  (set-naming {:keys str/lower-case})
+  (dosync (alter geppetto-db (constantly (mysql {:db "geppetto_test" :user "travis" :password ""
+                                                 :naming {:keys str/lower-case}
+                                                 :delimiters "`"}))))
   (establish-params)
   (f))
 


### PR DESCRIPTION
Uses Korma 0.4.5, removes references to korma.config, and uses the contemporary delimiter and naming configuration API.